### PR TITLE
Found problem with fullup of product ID and Serial Number

### DIFF
--- a/mtx-1.3.12/mtx.c
+++ b/mtx-1.3.12/mtx.c
@@ -1040,6 +1040,17 @@ int parse_args(void)
 			device = argv[i++];
 			open_device(); /* open the device and do a status scan on it... */
 		}
+		else if (strcmp(argv[i], "-a") == 0)
+		{
+			printf("absolute addressing\n");
+			i++;
+                        if (i >= argc)
+                        {
+                                Usage();
+                        }
+			absolute_addressing = 1;
+		}
+
 		else
 		{
 			cmd_tbl_idx = 0;		/* default to the first command... */

--- a/mtx-1.3.12/mtx.h
+++ b/mtx-1.3.12/mtx.h
@@ -565,7 +565,10 @@ TransportElementDescriptor_T;
 /* Now for element status data; */
 
 typedef unsigned char barcode[37];
+//typedef unsigned char serialnumber[13];
 typedef unsigned char serialnumber[13];
+typedef unsigned char devicetype[17];
+
 
 typedef struct ElementStatus {
 
@@ -575,7 +578,7 @@ typedef struct ElementStatus {
   int *DataTransferElementAddress;  /* array. */
   int *DataTransferElementSourceStorageElementNumber; /* array */
   int *DataTransferElementPhysicalLocation; /*array */ 
-  serialnumber *DataTransferElementProductId; /*array */ 
+  devicetype *DataTransferElementProductId; /*array */ 
   serialnumber *DataTransferElementSerialNumber; /*array */ 
   barcode *StorageElementPhysicalLocation; /*array */ 
   barcode *DataTransferPrimaryVolumeTag; /* array. */

--- a/mtx-1.3.12/mtx.spec
+++ b/mtx-1.3.12/mtx.spec
@@ -1,6 +1,6 @@
 Name: mtx
 Version: 1.3.12
-Release: 15fnal%{?dist}
+Release: 19fnal_jinr%{?dist}
 Summary: SCSI media changer control program
 License: GPLv2
 Group: Applications/System
@@ -51,6 +51,10 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Thu Dec 07 2023 Alexander Moibenko <moibenko@jinr.ru> - 1.3.12-19fnal
+- mtx CLI hasn hidden option (-a) to show status information with absolute addresses
+- Fixed problem seen in JINR where serial number was missing few last symbols 
+
 * Wed Jan 23 2019 Alexander Moibenko <moibenko@fnal.gov> - 1.3.12-15fnal
 - For absolute_addressing refresh elements data when status command is executed. This is needed to update tape library infortion in the calling program.
 - Changes to allow to use mtx as library and show absolute transfer and storage elements as output of status call

--- a/mtx-1.3.12/mtxl.c
+++ b/mtx-1.3.12/mtxl.c
@@ -563,7 +563,7 @@ static ElementStatus_T *AllocateElementData(ElementModeSense_T *mode_sense)
 	retval->DataTransferElementPhysicalLocation =
 		(int *)xzmalloc(sizeof(int) * (mode_sense->NumDataTransfer + 1));
 	retval->DataTransferElementProductId =
-		(serialnumber *)xzmalloc(sizeof(serialnumber) * (mode_sense->NumDataTransfer + 1));
+		(devicetype *)xzmalloc(sizeof(devicetype) * (mode_sense->NumDataTransfer + 1));
 	retval->DataTransferElementSerialNumber =
 		(serialnumber *)xzmalloc(sizeof(serialnumber) * (mode_sense->NumDataTransfer + 1));
 	retval->StorageElementPhysicalLocation =
@@ -618,9 +618,16 @@ void copy_physical_location(unsigned char *src, unsigned char *dest)
 void copy_char_buffer(unsigned char *src, unsigned char *dest, int num)
 {
   int i;
-  while ((*src< 32) || (*src > 127)) {
+  char *dest_tmp;
+  dest_tmp = dest;
+  while ((*src<= 32) || (*src > 127)) {
     src++;
   }
+  for (i=0; i < num; i++)
+ {
+   *dest_tmp++ = 0;
+ }
+
   for (i=0; i < num; i++)
  {
    *dest = *src++;


### PR DESCRIPTION
Found problem with fillup of product ID and Serial Number field red by SCSI Read element status.

This was not seen before in all installed systems. JINR TS4500 exposed this problem 1-st time.